### PR TITLE
Auto-deploy to GitHub Pages via GitHub Actions

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,28 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: yarn install --frozen-lockfile
+      - run: yarn build
+      - uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist

--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,3 @@ yarn-error.log*
 *.njsproj
 *.sln
 *.sw?
-vue.config.js

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  publicPath: process.env.NODE_ENV === 'production' ? '/vueapp/' : '/'
+}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/deploy-pages.yml`: on every push to `master`, builds the app and publishes `dist/` to the `gh-pages` branch via `peaceiris/actions-gh-pages`, matching this repo's existing Pages setup (a `gh-pages` branch with a prior manual "rebuild" deploy already exists)
- Adds `vue.config.js` with `publicPath: '/vueapp/'` in production, matching the asset paths already baked into the committed `dist/` — previously this file was in `.gitignore`, so CI had no way to reproduce that build
- Un-ignores `vue.config.js` in `.gitignore` so it's tracked

## Test plan
- [x] `NODE_ENV=production npx vue-cli-service build` compiles and emits `/vueapp/`-prefixed asset paths in `dist/index.html`, matching the previously committed build
- [ ] After merge, confirm the Actions run succeeds and https://alishajava.github.io/vueapp/ serves the updated build (this environment's network policy blocks outbound requests to *.github.io, so it could not be verified from here)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BA7AbctyzSKZqUe5cbmmte)_