### PR TITLE
Bump CI Node version to 20 for Firebase SDK

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - run: yarn install --frozen-lockfile
       - run: yarn build
       - uses: peaceiris/actions-gh-pages@v4


### PR DESCRIPTION
## Summary
- The `Deploy to GitHub Pages` workflow's most recent run (after merging Firebase support) failed at `yarn install --frozen-lockfile`: `@firebase/ai@2.15.0` requires Node `>=20.0.0`, but the workflow pinned `node-version: 18`
- Bumped `actions/setup-node` to `node-version: 20`

## Test plan
- [x] Confirmed the failure in the Actions log (engine mismatch on `@firebase/ai`)
- [ ] Next push to `master` should now deploy successfully — will confirm after merge

---
_Generated by [Claude Code](https://claude.ai/code/session_01BA7AbctyzSKZqUe5cbmmte)_