### PR TITLE
Document the composite index the todos query needs

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,13 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "todos",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "uid", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "ASCENDING" }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}


### PR DESCRIPTION
## Summary
- `TodoList.vue`'s query (`where uid ==` + `orderBy createdAt`) requires a Firestore composite index, which isn't auto-created
- Adds `firestore.indexes.json` documenting that index (`uid` ASC, `createdAt` ASC) alongside `firestore.rules`, for reference — not auto-deployed; create it via the console link Firestore surfaces on the index-required error (same manual step as the security rules)

## Test plan
- Docs-only change, no app code touched

---
_Generated by [Claude Code](https://claude.ai/code/session_01BA7AbctyzSKZqUe5cbmmte)_