### PR TITLE
Add AG Grid CRUD board and Chart.js todo stats

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -8,5 +8,13 @@ service cloud.firestore {
       allow create: if request.auth != null
         && request.auth.uid == request.resource.data.uid;
     }
+
+    match /posts/{postId} {
+      allow read: if request.auth != null;
+      allow create: if request.auth != null
+        && request.auth.uid == request.resource.data.uid;
+      allow update, delete: if request.auth != null
+        && request.auth.uid == resource.data.uid;
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,9 +8,13 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
+    "ag-grid-community": "^36.1.0",
+    "ag-grid-vue3": "^36.1.0",
+    "chart.js": "^4.5.1",
     "core-js": "^3.8.3",
     "firebase": "^12.18.0",
     "vue": "^3.4.0",
+    "vue-chartjs": "^5.3.4",
     "websocket-extensions": "^0.1.4"
   },
   "devDependencies": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -3,18 +3,24 @@
     <img alt="Vue logo" src="./assets/logo.png">
     <HelloWorld msg="당신의 Vue.js 앱에 오신 것을 환영합니다"/>
     <TodoList/>
+    <TodoStats/>
+    <PostBoard/>
   </div>
 </template>
 
 <script>
 import HelloWorld from './components/HelloWorld.vue'
 import TodoList from './components/TodoList.vue'
+import TodoStats from './components/TodoStats.vue'
+import PostBoard from './components/PostBoard.vue'
 
 export default {
   name: 'App',
   components: {
     HelloWorld,
-    TodoList
+    TodoList,
+    TodoStats,
+    PostBoard
   }
 }
 </script>

--- a/src/components/PostBoard.vue
+++ b/src/components/PostBoard.vue
@@ -1,0 +1,227 @@
+<template>
+  <div class="board">
+    <h3>게시판</h3>
+
+    <p v-if="!authReady" class="status">로그인 상태 확인 중...</p>
+    <p v-else-if="!user" class="status">게시판은 로그인 후 이용할 수 있어요.</p>
+
+    <template v-else>
+      <form class="post-form" @submit.prevent="addPost">
+        <input v-model="newTitle" type="text" placeholder="제목" aria-label="제목">
+        <input v-model="newContent" type="text" placeholder="내용" aria-label="내용">
+        <button type="submit">등록</button>
+      </form>
+
+      <p v-if="boardError" class="error">{{ boardError }}</p>
+
+      <div class="grid-wrap">
+        <ag-grid-vue
+          style="width: 100%; height: 320px;"
+          :theme="gridTheme"
+          :rowData="posts"
+          :columnDefs="columnDefs"
+          :defaultColDef="defaultColDef"
+          @cell-value-changed="onCellValueChanged"
+          @cell-clicked="onCellClicked"
+        />
+      </div>
+      <p class="hint">제목/내용 칸을 더블클릭하면 본인 글은 수정할 수 있어요. 다른 사람 글은 읽기만 가능합니다.</p>
+    </template>
+  </div>
+</template>
+
+<script>
+import { AgGridVue } from 'ag-grid-vue3'
+import { ModuleRegistry, AllCommunityModule, themeQuartz } from 'ag-grid-community'
+import {
+  auth,
+  db,
+  onAuthStateChanged,
+  collection,
+  query,
+  orderBy,
+  onSnapshot,
+  addDoc,
+  updateDoc,
+  deleteDoc,
+  doc,
+  serverTimestamp
+} from '../firebase'
+
+ModuleRegistry.registerModules([AllCommunityModule])
+
+export default {
+  name: 'PostBoard',
+  components: { AgGridVue },
+  data() {
+    return {
+      authReady: false,
+      user: null,
+      rawPosts: [],
+      newTitle: '',
+      newContent: '',
+      boardError: '',
+      unsubscribeAuth: null,
+      unsubscribePosts: null,
+      gridTheme: themeQuartz,
+      defaultColDef: { resizable: true, sortable: true, filter: true }
+    }
+  },
+  computed: {
+    posts() {
+      return this.rawPosts.map(p => ({
+        ...p,
+        createdAtText: p.createdAt ? p.createdAt.toDate().toLocaleString('ko-KR') : ''
+      }))
+    },
+    columnDefs() {
+      const isOwn = (params) => !!this.user && params.data.uid === this.user.uid
+      return [
+        { field: 'title', headerName: '제목', editable: isOwn, flex: 2 },
+        { field: 'content', headerName: '내용', editable: isOwn, flex: 3 },
+        { field: 'author', headerName: '작성자', editable: false, width: 120 },
+        { field: 'createdAtText', headerName: '작성일', editable: false, width: 160 },
+        {
+          headerName: '',
+          colId: 'actions',
+          width: 90,
+          editable: false,
+          cellRenderer: (params) => {
+            if (!isOwn(params)) return ''
+            return '<button type="button" class="grid-delete-btn">삭제</button>'
+          }
+        }
+      ]
+    }
+  },
+  mounted() {
+    this.unsubscribeAuth = onAuthStateChanged(auth, (user) => {
+      this.authReady = true
+      this.user = user
+      this.subscribePosts()
+    })
+  },
+  beforeUnmount() {
+    if (this.unsubscribeAuth) this.unsubscribeAuth()
+    if (this.unsubscribePosts) this.unsubscribePosts()
+  },
+  methods: {
+    subscribePosts() {
+      if (this.unsubscribePosts) {
+        this.unsubscribePosts()
+        this.unsubscribePosts = null
+      }
+      this.rawPosts = []
+      if (!this.user) return
+
+      const postsQuery = query(collection(db, 'posts'), orderBy('createdAt', 'asc'))
+      this.unsubscribePosts = onSnapshot(postsQuery, (snapshot) => {
+        this.rawPosts = snapshot.docs.map(d => ({ id: d.id, ...d.data() }))
+      }, (err) => {
+        this.boardError = this.describeError(err)
+      })
+    },
+    async addPost() {
+      const title = this.newTitle.trim()
+      const content = this.newContent.trim()
+      if (!title || !this.user) return
+      this.boardError = ''
+      try {
+        await addDoc(collection(db, 'posts'), {
+          uid: this.user.uid,
+          author: this.user.displayName || this.user.email,
+          title,
+          content,
+          createdAt: serverTimestamp()
+        })
+        this.newTitle = ''
+        this.newContent = ''
+      } catch (err) {
+        this.boardError = this.describeError(err)
+      }
+    },
+    async onCellValueChanged(event) {
+      if (event.colDef.field !== 'title' && event.colDef.field !== 'content') return
+      if (!this.user || event.data.uid !== this.user.uid) return
+      this.boardError = ''
+      try {
+        await updateDoc(doc(db, 'posts', event.data.id), { [event.colDef.field]: event.newValue })
+      } catch (err) {
+        this.boardError = this.describeError(err)
+      }
+    },
+    async onCellClicked(event) {
+      if (event.colDef.colId !== 'actions') return
+      if (!event.event.target.classList.contains('grid-delete-btn')) return
+      if (!this.user || event.data.uid !== this.user.uid) return
+      this.boardError = ''
+      try {
+        await deleteDoc(doc(db, 'posts', event.data.id))
+      } catch (err) {
+        this.boardError = this.describeError(err)
+      }
+    },
+    describeError(err) {
+      if (err && err.code === 'permission-denied') {
+        return '권한이 없어요. Firestore 보안 규칙(firestore.rules)에 posts 컬렉션 규칙이 게시되어 있는지 확인해주세요.'
+      }
+      return '문제가 발생했어요: ' + (err && err.message ? err.message : String(err))
+    }
+  }
+}
+</script>
+
+<style scoped>
+.board {
+  max-width: 700px;
+  margin: 40px auto 0;
+  text-align: left;
+}
+
+.status,
+.hint {
+  color: #888;
+  font-size: 13px;
+}
+
+.error {
+  color: #c0392b;
+  font-size: 13px;
+}
+
+.post-form {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.post-form input[type='text'] {
+  flex: 1;
+  padding: 8px 10px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 14px;
+}
+
+.post-form button {
+  padding: 8px 16px;
+  border: none;
+  border-radius: 4px;
+  background-color: #42b983;
+  color: #fff;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.post-form button:hover {
+  background-color: #369870;
+}
+
+.grid-wrap :deep(.grid-delete-btn) {
+  border: none;
+  background: none;
+  color: #c0392b;
+  cursor: pointer;
+  font-size: 13px;
+}
+</style>

--- a/src/components/TodoStats.vue
+++ b/src/components/TodoStats.vue
@@ -1,0 +1,156 @@
+<template>
+  <div class="todo-stats">
+    <h3>할 일 통계</h3>
+
+    <p v-if="!authReady" class="status">로그인 상태 확인 중...</p>
+    <p v-else-if="!user" class="status">로그인하면 통계를 볼 수 있어요.</p>
+    <p v-else-if="todos.length === 0" class="status">아직 통계를 낼 데이터가 없어요. 할 일을 추가해보세요.</p>
+
+    <div v-else class="charts">
+      <div class="chart-box">
+        <h4>완료 현황</h4>
+        <Doughnut :data="statusChartData" :options="doughnutOptions" />
+      </div>
+      <div class="chart-box">
+        <h4>날짜별 등록 개수</h4>
+        <Bar :data="dailyChartData" :options="barOptions" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { Doughnut, Bar } from 'vue-chartjs'
+import {
+  Chart as ChartJS,
+  ArcElement,
+  BarElement,
+  CategoryScale,
+  LinearScale,
+  Tooltip,
+  Legend
+} from 'chart.js'
+import {
+  auth,
+  db,
+  onAuthStateChanged,
+  collection,
+  query,
+  where,
+  orderBy,
+  onSnapshot
+} from '../firebase'
+
+ChartJS.register(ArcElement, BarElement, CategoryScale, LinearScale, Tooltip, Legend)
+
+export default {
+  name: 'TodoStats',
+  components: { Doughnut, Bar },
+  data() {
+    return {
+      authReady: false,
+      user: null,
+      todos: [],
+      unsubscribeAuth: null,
+      unsubscribeTodos: null,
+      doughnutOptions: { responsive: true, maintainAspectRatio: false },
+      barOptions: {
+        responsive: true,
+        maintainAspectRatio: false,
+        scales: { y: { beginAtZero: true, ticks: { precision: 0 } } }
+      }
+    }
+  },
+  computed: {
+    statusChartData() {
+      const done = this.todos.filter(t => t.done).length
+      const remaining = this.todos.length - done
+      return {
+        labels: ['완료', '미완료'],
+        datasets: [{
+          data: [done, remaining],
+          backgroundColor: ['#42b983', '#e0e0e0']
+        }]
+      }
+    },
+    dailyChartData() {
+      const counts = {}
+      this.todos.forEach(todo => {
+        if (!todo.createdAt) return
+        const day = todo.createdAt.toDate().toISOString().slice(0, 10)
+        counts[day] = (counts[day] || 0) + 1
+      })
+      const labels = Object.keys(counts).sort()
+      return {
+        labels,
+        datasets: [{
+          label: '등록 개수',
+          data: labels.map(day => counts[day]),
+          backgroundColor: '#42b983'
+        }]
+      }
+    }
+  },
+  mounted() {
+    this.unsubscribeAuth = onAuthStateChanged(auth, (user) => {
+      this.authReady = true
+      this.user = user
+      this.subscribeTodos()
+    })
+  },
+  beforeUnmount() {
+    if (this.unsubscribeAuth) this.unsubscribeAuth()
+    if (this.unsubscribeTodos) this.unsubscribeTodos()
+  },
+  methods: {
+    subscribeTodos() {
+      if (this.unsubscribeTodos) {
+        this.unsubscribeTodos()
+        this.unsubscribeTodos = null
+      }
+      this.todos = []
+      if (!this.user) return
+
+      const todosQuery = query(
+        collection(db, 'todos'),
+        where('uid', '==', this.user.uid),
+        orderBy('createdAt', 'asc')
+      )
+      this.unsubscribeTodos = onSnapshot(todosQuery, (snapshot) => {
+        this.todos = snapshot.docs.map(d => ({ id: d.id, ...d.data() }))
+      })
+    }
+  }
+}
+</script>
+
+<style scoped>
+.todo-stats {
+  max-width: 700px;
+  margin: 40px auto 0;
+  text-align: left;
+}
+
+.status {
+  color: #888;
+  font-size: 13px;
+}
+
+.charts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px;
+}
+
+.chart-box {
+  flex: 1;
+  min-width: 260px;
+  height: 260px;
+}
+
+.chart-box h4 {
+  margin: 0 0 8px;
+  font-size: 14px;
+  color: #555;
+}
+</style>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1381,6 +1381,11 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@kurkle/color@^0.3.0":
+  version "0.3.4"
+  resolved "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz#4d4ff677e1609214fc71c580125ddddd86abcabf"
+  integrity sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==
+
 "@leichtgewicht/ip-codec@^2.0.1":
   version "2.0.5"
   resolved "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz#4fc56c15c580b9adb7dc3c333a134e540b44bfb1"
@@ -2235,6 +2240,31 @@ address@^1.1.2:
   resolved "https://registry.npmjs.org/address/-/address-1.2.2.tgz#2b5248dac5485a6390532c6a517fda2e3faac89e"
   integrity sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==
 
+ag-charts-types@14.1.0:
+  version "14.1.0"
+  resolved "https://registry.npmjs.org/ag-charts-types/-/ag-charts-types-14.1.0.tgz#148a76c103b804301e9c9c8a194568acfac77aae"
+  integrity sha512-mmzkng88c0l+Z9PvCMowMilhVeNgDU/iMuMemcOQD4BG/qO4vbkxWvyQO0iqju8Dx7YOY81PNzC/RmElQNiVkA==
+
+ag-grid-community@36.1.0, ag-grid-community@^36.1.0:
+  version "36.1.0"
+  resolved "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-36.1.0.tgz#3f228f5c6511049f3059b2b6d4268f67632727b6"
+  integrity sha512-WnvSQ4csRs8gv/b1B0lPHykQXvUJVgi2u5mpY0Aa6dv3pvhDVVqCT8dwUyOeCog4JNPptaXGrOrZ8qP2XoJzVA==
+  dependencies:
+    ag-charts-types "14.1.0"
+    ag-stack "36.1.0"
+
+ag-grid-vue3@^36.1.0:
+  version "36.1.0"
+  resolved "https://registry.npmjs.org/ag-grid-vue3/-/ag-grid-vue3-36.1.0.tgz#b2d999ab465c2a6c8a127473809dad6f49a78744"
+  integrity sha512-lktl90iQG4xfa9EbLxdNlSARPuQvs8lDSQADRmWt4OB2ZGTnTr18xMh+ApUNS6qVCBoMGAdkKI/5nVTy/3owDA==
+  dependencies:
+    ag-grid-community "36.1.0"
+
+ag-stack@36.1.0:
+  version "36.1.0"
+  resolved "https://registry.npmjs.org/ag-stack/-/ag-stack-36.1.0.tgz#3e2ef865b9b66b28100d99fc3c41d6ac783f33bd"
+  integrity sha512-Kmkf5iRZmyduNx2KtW450j6GbCdJ4ejacSpb1AWl0yrdquRmScLRc1SlLolx6lyCbTBSJGo4tRraKbBzre+GlQ==
+
 ajv-formats@^2.1.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz#6e669400659eb74973bbf2e33327180a0996b520"
@@ -2642,6 +2672,13 @@ chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+chart.js@^4.5.1:
+  version "4.5.1"
+  resolved "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz#19dd1a9a386a3f6397691672231cb5fc9c052c35"
+  integrity sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==
+  dependencies:
+    "@kurkle/color" "^0.3.0"
 
 chokidar@^3.5.3:
   version "3.6.0"
@@ -6384,6 +6421,11 @@ vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
+
+vue-chartjs@^5.3.4:
+  version "5.3.4"
+  resolved "https://registry.npmjs.org/vue-chartjs/-/vue-chartjs-5.3.4.tgz#9a0f102a56504824674d01d35eece40e2f6b186c"
+  integrity sha512-x3Fqob8RQvrTdssfi9ecsCzEkFOd8JPmNwSkSQzdfKj/uBsRJs/Y88cZcZIEcPsTVfMGwMo4MOoihoDG2DoE/g==
 
 vue-eslint-parser@^9.4.3:
   version "9.4.3"


### PR DESCRIPTION
## Summary
- **`PostBoard.vue`**: a shared bulletin board backed by a new Firestore `posts` collection, rendered with `ag-grid-vue3`. Any signed-in user can read all posts; inline cell editing (title/content) and delete are restricted to the post's own `uid`, both in the UI (editable/delete button only shown for own rows) and enforced server-side via updated `firestore.rules`
- **`TodoStats.vue`**: Chart.js (`vue-chartjs`) dashboard for the signed-in user's todos — a doughnut of done vs. remaining, and a bar chart of todos created per day
- Both mounted in `App.vue` below `TodoList`; both gate on the same Google-auth state used elsewhere in the app

## Manual setup still needed
- [ ] Re-publish the updated `firestore.rules` (now includes a `posts` collection block) in Firebase Console → Firestore Database → 규칙

## Test plan
- [x] `yarn build` compiles with no errors (ESLint's `multi-word-component-names` forced `Board.vue` → `PostBoard.vue`)
- [x] Logged-out state for all three Firebase-backed sections (TodoList, TodoStats, PostBoard) verified via headless browser — renders correctly with zero console errors
- [ ] Grid editing/delete and chart rendering with real data need manual verification with a real Google account after merge + republishing the rules, same constraint as the original Firebase PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01BA7AbctyzSKZqUe5cbmmte)_